### PR TITLE
Si centralsite

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,15 +20,15 @@ COPY requirements.txt /code/requirements.txt
 RUN pip3 install -r /code/requirements.txt
 
 RUN mkdir /db /run/secrets
-RUN chown -R apache:apache /db /var/www /run/secrets
+RUN chown -R 1000:1000 /db /var/www /run/secrets
 
-RUN ln -s /dev/stdout /etc/httpd/logs/access_log
-RUN ln -s /dev/stderr /etc/httpd/logs/error_log
+RUN ln -s /dev/stdout /home/access_log
+RUN ln -s /dev/stderr /home/error_log
 
-RUN chown apache:apache /etc/httpd/logs/error_log  
-RUN chown apache:apache /etc/httpd/logs/access_log  
-RUN chmod 666 /etc/httpd/logs/error_log
-RUN chmod 666 /etc/httpd/logs/access_log
+RUN chown 1000:1000 /home/error_log
+RUN chown 1000:1000 /home/access_log   
+RUN chmod 777  /home/error_log
+RUN chmod 777 /home/access_log  
 
 ENV HOME /root
 ENV REQUESTS_CA_BUNDLE /etc/ssl/certs/ca-bundle.crt
@@ -64,8 +64,7 @@ COPY models /var/www/cgi-bin/models
 COPY modules /var/www/cgi-bin/modules
 COPY config /var/www/public/config
 
-RUN chgrp -R 0 /run && chmod -R g=u /run
-RUN chgrp -R 0 /etc/httpd/logs && chmod -R g=u /etc/httpd/logs
+RUN chgrp -R 1000 /run && chmod -R g=u /run
+RUN chgrp -R 1000 /etc/httpd/logs && chmod -R g=u /etc/httpd/logs
 
 CMD ["/usr/sbin/httpd","-D","FOREGROUND"]
-

--- a/config/DT.json
+++ b/config/DT.json
@@ -2,17 +2,10 @@
   "main_gdir": "DQMData/Run {0}/DT/Run summary/",
   "hists": [{
       "norm_type": "row",
-      "path": "02-Segments/SegmentGlbSummary"
-},{
-      "norm_type": "row",
       "path": "02-Segments/00-MeanRes/MeanDistr"
 },{
       "norm_type": "row",
       "path": "02-Segments/01-SigmaRes/SigmaDistr"
-},{
-
-      "norm_type": "row",
-      "path": "02-Segments/*"
 },
 {
       "comparators": ["pca", "ks_test"],

--- a/httpd.conf
+++ b/httpd.conf
@@ -81,7 +81,8 @@ DocumentRoot "/var/www/public"
     Require all denied
 </Files>
 
-ErrorLog "logs/error_log"
+# changed error log location from 
+ErrorLog "/home/error_log"
 LogLevel warn
 
 <IfModule log_config_module>
@@ -91,7 +92,7 @@ LogLevel warn
     <IfModule logio_module>
       LogFormat "%h %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
     </IfModule>
-    CustomLog "logs/access_log" combined
+    CustomLog "/home/access_log" combined
 </IfModule>
 
 <IfModule mime_module>

--- a/webapp/src/plots/PlotsPage.js
+++ b/webapp/src/plots/PlotsPage.js
@@ -116,7 +116,7 @@ export default class PlotsPage extends Component {
     //chunk_size is the number of plots processeed in each chunk
     var plots = [];
     var chunk_index = 0;
-    const chunk_size = 200;
+    const chunk_size = 60;
 
     Promise.all([refReq, dataReq])
       .then(res => {


### PR DESCRIPTION
works on group 1000 without time out 

Dockerfile - changed group ownership of files to 1000 
httpd.comf - changed the locations of /dev/stdout and /dev/stderr so that apache can access them without being root 
DT.json - removed plots that are not filled with events based 
PlotsPage.js - reduce chunk_size to avoid timeouts 