### PR TITLE
Refresh fix

### DIFF
--- a/httpd.conf
+++ b/httpd.conf
@@ -51,7 +51,7 @@ DocumentRoot "/var/www/public"
     RewriteRule ^index\.html$ - [L]
     RewriteCond %{REQUEST_FILENAME} !-f
     RewriteCond %{REQUEST_FILENAME} !-d
-     RewriteRule ^ index.html [L]
+    RewriteRule ^ index.html [L]
     # Rewrite everything else to index.html to allow html5 state links
 </Directory>
 

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -21,6 +21,6 @@
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
   },
-  "homepage":".",
+  "homepage":"/dqm/autodqm",
   "proxy": "0.0.0.0:8083"
 }

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -62,7 +62,7 @@ class App extends Component {
               )}
             />
             <Route
-              path="/plots/:subsystem/:refSeries/:refSample/:refRun/:dataSeries/:dataSample/:dataRun"
+              path="/plots/:subsystem/:refSeries/:refSample/:refRun/:dataSeries/:dataSample/:dataRun" 
               render={props => (
                 <PlotsPage onNewQuery={this.handleNewQuery} {...props} />
               )}


### PR DESCRIPTION
fixes the problem with refereshing PlotsPage and that leading to a blank page. 

`webapp/src/App.js` --> the "homepage" is changed to "/dqm/autodqm" for correct redirection. 