### PR TITLE
Add OnlineData source and L1T quick collection workpace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN pip3 install -r /code/requirements.txt
 
 RUN mkdir /db /run/secrets
 RUN chown -R 1000:1000 /db /var/www /run/secrets
-RUN chmod -R 755 /db
+RUN chmod -R 777 /db
 
 RUN ln -s /dev/stdout /home/access_log
 RUN ln -s /dev/stderr /home/error_log

--- a/autodqm/cfg.py
+++ b/autodqm/cfg.py
@@ -29,5 +29,15 @@ def get_subsystem(cfg_dir, subsystem):
         return json.load(f)
 
 
+def get_main(cfg_dir):
+    """Return the dict-based main configuration of from cfg_dir."""
+    path = os.path.join(cfg_dir, MAIN_CFG)
+    if not os.path.exists(path):
+        raise error("Main config '{0}' not found.".format(MAIN_CFG))
+
+    with open(os.path.join(cfg_dir, MAIN_CFG)) as f:
+        return json.load(f)
+
+
 class error(Exception):
     pass

--- a/autodqm/compare_hists.py
+++ b/autodqm/compare_hists.py
@@ -95,6 +95,9 @@ def compile_histpairs(chunk_index, chunk_size, config_dir,
     ref_file = uproot.open(ref_path)
 
     histPairs = []
+    
+    missing_data_dirs = []
+    missing_ref_dirs  = []
 
     for hconf in conf_list:
         # Get name of hist in root file
@@ -104,16 +107,22 @@ def compile_histpairs(chunk_index, chunk_size, config_dir,
 
         data_dirname = "{0}{1}".format(main_gdir.format(data_run), gdir)
         ref_dirname = "{0}{1}".format(main_gdir.format(ref_run), gdir)
-
-        data_dir = data_file[data_dirname[:-1]]
-        ref_dir = ref_file[ref_dirname[:-1]]
+        
+        try:
+            data_dir = data_file[data_dirname[:-1]]
+        except:
+            missing_data_dirs.append(data_dirname)
+            continue
+        try:
+            ref_dir = ref_file[ref_dirname[:-1]]
+        except:
+            missing_ref_dirs.append(ref_dirname)
+            continue
 
         if not data_dir:
-            raise error(
-                "Subsystem dir {0} not found in data root file".format(data_dirname))
+            raise error("Subsystem dir {0} not found in data root file".format(data_dirname))
         if not ref_dir:
-            raise error(
-                "Subsystem dir {0} not found in ref root file".format(ref_dirname))
+            raise error("Subsystem dir {0} not found in ref root file".format(ref_dirname))
 
         data_keys = data_dir.keys()
         ref_keys = ref_dir.keys()
@@ -146,6 +155,17 @@ def compile_histpairs(chunk_index, chunk_size, config_dir,
                                          data_series, data_sample, data_run, str(name[:-2]), data_hist,
                                          ref_series, ref_sample, ref_run, str(name[:-2]), ref_hist)
                         histPairs.append(hPair)
+
+    ## TODO: "raise warning" is not an actual function, but need some way to alert
+    ## TODO: users that histograms in json config file are missing from ROOT files - AWB 2022.06.11
+    # if len(missing_data_dirs) > 0:
+    #     raise warning("The folloing subsystem dirs not found in data root file")
+    #     for missing_data_dir in missing_data_dirs:
+    #         raise warning("{0}".format(missing_data_dir))
+    # if len(missing_ref_dirs) > 0:
+    #     raise warning("The folloing subsystem dirs not found in ref root file")
+    #     for missing_ref_dir in missing_ref_dirs:
+    #         raise warning("{0}".format(missing_ref_dirs))
 
     #Return histpairs that match the chunk_index <<CAN BE IMPROVED IN THE FUTURE TO BE MORE EFFICIENT>>
     return histPairs[min(chunk_index, len(histPairs)):min(chunk_index+chunk_size, len(histPairs))] 

--- a/autodqm/compare_hists.py
+++ b/autodqm/compare_hists.py
@@ -11,14 +11,16 @@ from autodqm.histpair import HistPair
 import plotly
 
 
-def process(chunk_index, chunk_size, config_dir, subsystem,
+def process(chunk_index, chunk_size, config_dir,
+            dqmSource, subsystem,
             data_series, data_sample, data_run, data_path,
             ref_series, ref_sample, ref_run, ref_path,
             output_dir='./out/', plugin_dir='./plugins/'):
 
     # Ensure no graphs are drawn to screen and no root messages are sent to
     # terminal
-    histpairs = compile_histpairs(chunk_index, chunk_size, config_dir, subsystem,
+    histpairs = compile_histpairs(chunk_index, chunk_size, config_dir,
+                                  dqmSource, subsystem,
                                   data_series, data_sample, data_run, data_path,
                                   ref_series, ref_sample, ref_run, ref_path)
 
@@ -78,7 +80,8 @@ def process(chunk_index, chunk_size, config_dir, subsystem,
 
     return hist_outputs
 
-def compile_histpairs(chunk_index, chunk_size, config_dir, subsystem,
+def compile_histpairs(chunk_index, chunk_size, config_dir,
+                      dqmSource, subsystem,
                       data_series, data_sample, data_run, data_path,
                       ref_series, ref_sample, ref_run, ref_path):
 

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -31,6 +31,8 @@ OnlineMap = dict({'CaloLayer1':'L1T',
                   'EMTF':'L1T',
                   'OMTF':'L1T',
                   'uGMT':'L1T',
+                  'L1T_workspace':'L1T',
+                  'L1T_workspace_slim':'L1T',
                   'CSC':'CSC',
                   'RPC':'RPC',
                   'DT':'DT'})

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -11,7 +11,7 @@ from collections import namedtuple
 from requests_futures.sessions import FuturesSession
 
 TIMEOUT = 5
-VERBOSE = 1
+VERBOSE = 0
 BASE_URL = 'https://cmsweb.cern.ch'
 DQM_URL = 'https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/'
 CA_URL = 'https://cafiles.cern.ch/cafiles/certificates/CERN%20Root%20Certification%20Authority%202.crt'

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -77,7 +77,7 @@ class DQMSession(FuturesSession):
         if VERBOSE: print('\ndqm.py stream_run(dqmSource = %s, subsystem = %s, series = %s, sample = %s, run = %s, chunk_size = %d)' %
                           (dqmSource, subsystem, series, sample, run, chunk_size))
 
-        run_path = self._run_path(series, sample, run)
+        run_path = self._run_path(dqmSource, subsystem, series, sample, run)
         run_dir = os.path.dirname(run_path)
 
         if not os.path.exists(run_path):
@@ -238,9 +238,15 @@ class DQMSession(FuturesSession):
             os.remove(dest)
             raise
 
-    def _run_path(self, series, sample, run):
+    def _run_path(self, dqmSource, subsystem, series, sample, run):
         """Return the path to the specified run data file in the cached db."""
-        return "{}/{}.root".format(os.path.join(self.db, series, sample), run)
+        if dqmSource == "Online":
+            return "{}/{}.root".format(os.path.join(self.db, dqmSource, series, sample, OnlineMap[subsystem]), run)
+        elif dqmSource == "Offline":
+            return "{}/{}.root".format(os.path.join(self.db, dqmSource, series, sample), run)
+        else:
+            raise error("dqm.py _run_path dqmSource = {}, not Onilne or Offline!".format(dqmSource))
+        
 
 
 def _parse_dqm_page(content):

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -121,14 +121,9 @@ class DQMSession(FuturesSession):
         """Return DQMRows corresponding to the samples available under the given series."""
         if VERBOSE: print('\ndqm.py fetch_sample_list(dqmSource = %s, series = %s)' % (dqmSource, series))
 
-        isOnline = (series.startswith('000') and series.endswith('xxxx'))
         series_rows = self.fetch_series_list(dqmSource)
-        if isOnline:
-            url = next((r.url for r in series_rows if r.name == series))
-            return _resolve(self._fetch_dqm_rows(url)).data
-        else:
-            url = next((r.url for r in series_rows if r.name == series))
-            return _resolve(self._fetch_dqm_rows(url)).data
+        url = next((r.url for r in series_rows if r.name == series))
+        return _resolve(self._fetch_dqm_rows(url)).data
 
     def fetch_run_list(self, dqmSource, subsystem, series, sample, selRun=None):
         """Return DQMRows corresponding to the runs available under the given series and sample."""

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -11,9 +11,9 @@ from collections import namedtuple
 from requests_futures.sessions import FuturesSession
 
 TIMEOUT = 5
-
+VERBOSE = 0
 BASE_URL = 'https://cmsweb.cern.ch'
-DQM_URL = 'https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/'
+DQM_URL = 'https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/'
 CA_URL = 'https://cafiles.cern.ch/cafiles/certificates/CERN%20Root%20Certification%20Authority%202.crt'
 
 # The following are appended to the db dir
@@ -41,11 +41,12 @@ class DQMSession(FuturesSession):
         if not os.path.exists(self.verify):
             _get_cern_ca(self.verify)
 
-    def fetch_run(self, series, sample, run):
+    def fetch_run(self, dqmSource, series, sample, run):
         """Fetch and cache a run data file.
-
         Returns the path to the downloaded file."""
-        dl = self.stream_run(series, sample, run)
+        if VERBOSE: print('\ndqm.py fetch_run(dqmSource = %s, series = %s, sample = %s, run = %s)' % (dqmSource, series, sample, run))
+        
+        dl = self.stream_run(dqmSource, series, sample, run)
 
         # Get the path from the first yield
         path = next(dl).path
@@ -53,66 +54,115 @@ class DQMSession(FuturesSession):
         # Finish the download
         for _ in dl:
             pass
+        if VERBOSE: print('  * path = %s' % path)
         return path
 
-    def stream_run(self, series, sample, run, chunk_size=4096):
+    def stream_run(self, dqmSource, series, sample, run, chunk_size=4096):
         """Stream and cache a run data file.
+        Returns a generator that yields StreamProg tuples corresponding to the download progress."""
+        if VERBOSE: print('\ndqm.py stream_run(dqmSource = %s, series = %s, sample = %s, run = %s, chunk_size = %d)' % (dqmSource, series, sample, run, chunk_size))
 
-        Returns a generator that yields StreamProg tuples corresponding to the
-        download progress."""
         run_path = self._run_path(series, sample, run)
         run_dir = os.path.dirname(run_path)
 
         if not os.path.exists(run_path):
             _try_makedirs(run_dir)
 
-            runs = self.fetch_run_list(series, sample)
-            run_info = next(r for r in runs if r.name == run)
+            runs = self.fetch_run_list(dqmSource, series, sample, run)
+
+            isOnline = (series.startswith('000') and series.endswith('xxxx'))
+            if isOnline:  ## Use cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OnlineData/
+                ## FIXME: Need to update "L1T" to variable string which depends on subsystem - AWB 2022.05.25
+                run_info = next(r for r in runs if r.name == run and 'L1T_R000' in r.full_name)
+            else:                   ## Use cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/
+                run_info = next(r for r in runs if r.name == run)
 
             for prog in self._stream_file(
                     run_info.url, run_path, chunk_size=chunk_size):
                 yield prog
 
         size = os.path.getsize(run_path)
+        if VERBOSE: print('  * run_path = %s, size = %d' % (run_path, size))
         yield StreamProg(size, size, run_path)
 
-    def fetch_series_list(self):
-        """Return DQMRows corresponding to the series available on DQM Offline."""
-        return _resolve(self._fetch_dqm_rows(DQM_URL)).data
+    def fetch_series_list(self, dqmSource):
+        """Return DQMRows corresponding to the series available on DQM Online or Offline."""
+        if VERBOSE: print('\ndqm.py fetch_series_list(%s)' % dqmSource)
 
-    def fetch_sample_list(self, series):
-        """Return DQMRows corresponding to the samples available under the given
-        series."""
-        series_rows = self.fetch_series_list()
-        url = next((r.url for r in series_rows if r.name == series))
-        return _resolve(self._fetch_dqm_rows(url)).data
+        if dqmSource == "Online":
+            series_list = []
+            for series in _resolve(self._fetch_dqm_rows(DQM_URL+'OnlineData/original/')).data:
+                if series.name.startswith('000') and series.name.endswith('xxxx'):
+                    series_list.append(series)
+            return series_list
+        elif dqmSource == "Offline":
+            return _resolve(self._fetch_dqm_rows(DQM_URL+'OfflineData/')).data
+        else:
+            raise error("dqm.py fetch_series_list dqmSource = {}, not Onilne or Offline!".format(dqmSource))
 
-    def fetch_run_list(self, series, sample):
-        """Return DQMRows corresponding to the runs available under the given
-        series and sample."""
-        sample_rows = self.fetch_sample_list(series)
-        sample_url = next((r.url for r in sample_rows if r.name == sample))
+    def fetch_sample_list(self, dqmSource, series):
+        """Return DQMRows corresponding to the samples available under the given series."""
+        if VERBOSE: print('\ndqm.py fetch_sample_list(dqmSource = %s, series = %s)' % (dqmSource, series))
 
-        # Get all run directories for this sample
-        macrorun_rows = _resolve(self._fetch_dqm_rows(sample_url)).data
+        isOnline = (series.startswith('000') and series.endswith('xxxx'))
+        series_rows = self.fetch_series_list(dqmSource)
+        if isOnline:
+            url = next((r.url for r in series_rows if r.name == series))
+            return _resolve(self._fetch_dqm_rows(url)).data
+        else:
+            url = next((r.url for r in series_rows if r.name == series))
+            return _resolve(self._fetch_dqm_rows(url)).data
+
+    def fetch_run_list(self, dqmSource, series, sample, selRun=None):
+        """Return DQMRows corresponding to the runs available under the given series and sample."""
+        if VERBOSE: print('\ndqm.py fetch_run_list(dqmSource = %s, series = %s, sample = %s, selRun = %s)' % (dqmSource, series, sample, selRun))
+        if selRun and len(str(selRun)) != 6:
+            raise error("dqm.py fetch_run_list selRun = {}, not 6 digits!".format(selRun))
+
+        ## Get list of samples within a series
+        ## For OfflineData, primary datasets within Run2018, Run2017, etc.
+        ## For OnlineData/original, list of run ranges by first 2 digits of run
+        sample_rows = self.fetch_sample_list(dqmSource, series)
+
+        isOnline = (series.startswith('000') and series.endswith('xxxx'))
+        if isOnline:
+            macrorun_rows = sample_rows
+        else:  ## Use cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/
+            sample_url = next((r.url for r in sample_rows if r.name == sample))
+            # Get all run directories for this sample
+            macrorun_rows = _resolve(self._fetch_dqm_rows(sample_url)).data
+
+        ## If fetch_run_list is called with a run number, return only selected rows
+        macrorun_rows_sel = []
+        for mr in macrorun_rows:
+            if isOnline and mr.name != sample: continue
+            if (not selRun) or (mr.name == '000'+str(selRun)[0:4]+'xx'):
+                macrorun_rows_sel.append(mr)
 
         # Determine which run directories are cached
         run_rows = []
         to_req = []
-        for mr in macrorun_rows:
+        for mr in macrorun_rows_sel:
             rows = self._get_cache(mr)
-            if rows:
+            ## If selecting a single run, the cache will not contain a full list of runs
+            if rows and not selRun:
                 run_rows += rows
             else:
                 to_req.append(mr)
 
-        # Request uncached directories from the servers
+        ## Select rows from these directories based on run number and sample (for OnlineData)
         futures = [(mr, self._fetch_dqm_rows(mr.url)) for mr in to_req]
         for mr, fut in futures:
             rows = _resolve(fut).data
-            run_rows += rows
+            for row in rows:
+                if selRun and row.name != selRun: continue
+                ## FIXME: Need to update "L1T" to variable string which depends on subsystem - AWB 2022.05.25
+                if isOnline and not ('L1T_R000' in row.full_name): continue
+                run_rows.append(row)
             self._write_cache(mr, rows)
 
+        if VERBOSE: print('  * len(run_rows) = %d' % len(run_rows))
+        if VERBOSE + (len(run_rows) < 20) >= 2: print(run_rows)
         return run_rows
 
     def _get_cache(self, parent_row):
@@ -139,7 +189,6 @@ class DQMSession(FuturesSession):
 
     def _fetch_dqm_rows(self, url, timeout=TIMEOUT):
         """Return a future of DQMRows of a DQM page at url.
-
         Access the array of DQMRows at _resolve(self._fetch_dqm_rows(...)).data"""
 
         # Callback to process dqm responses
@@ -180,8 +229,9 @@ class DQMSession(FuturesSession):
 
 
 def _parse_dqm_page(content):
-    """Return the contents of a DQM series, sample, or macrorun page as a list
-    of DQMRows."""
+    """Return the contents of a DQM series, sample, or macrorun page as a list of DQMRows."""
+    if VERBOSE >= 2: print('\ndqm.py _parse_dqm_page(content = %s)' % content)
+
     dqm_rows = []
     tree = lxml.html.fromstring(content)
     tree.make_links_absolute(BASE_URL)
@@ -202,14 +252,20 @@ def _parse_dqm_page(content):
 
 
 def _parse_run_full_name(full_name):
-    """Return the simplified form of a full DQM run name.
+    """Return the simplified form of a full DQM run name."""
+    if VERBOSE >= 2: print('\ndqm.py _parse_run_full_name(full_name = %s)' % full_name)
 
-    example:
-    DQM_V0001_R000316293__ZeroBias__Run2018A-PromptReco-v2__DQMIO.root
-    => 316293
-    """
-    name = full_name.split('_')[2][1:]
-    return str(int(name))
+    if full_name.split('_')[2].startswith('R000'):  ## Format for OfflineData
+        """example: DQM_V0001_R000316293__ZeroBias__Run2018A-PromptReco-v2__DQMIO.root => 316293"""
+        name = full_name.split('_')[2][1:]
+        return str(int(name))
+    elif full_name.split('_')[3].startswith('R000'):  ## Format for OnlineData
+        """example: DQM_V0001_SiStrip_R000351871.root => 351871"""
+        name = full_name.split('_')[3][1:].replace('.root','')
+        return str(int(name))
+    else:
+        raise error("dqm.py _parse_run_full_name({}), failed to parse run number!".format(full_name))
+        return 'NULL'
 
 
 def _get_cern_ca(path):

--- a/autodqm/dqm.py
+++ b/autodqm/dqm.py
@@ -7,6 +7,7 @@ import json
 import lxml.html
 import os
 import requests
+from autodqm import cfg
 from collections import namedtuple
 from requests_futures.sessions import FuturesSession
 
@@ -23,19 +24,9 @@ CA_PATH = 'CERN_Root_CA.crt'
 StreamProg = namedtuple('StreamProg', ('cur', 'total', 'path'))
 DQMRow = namedtuple('DQMRow', ('name', 'full_name', 'url', 'size', 'date'))
 
-## Map from subsystem to Online DQM directory
-## FIXME: Will break for any new subsystems added to config!!! - AWB 2022.05.25
-OnlineMap = dict({'CaloLayer1':'L1T',
-                  'CaloLayer2':'L1T',
-                  'BMTF':'L1T',
-                  'EMTF':'L1T',
-                  'OMTF':'L1T',
-                  'uGMT':'L1T',
-                  'L1T_workspace':'L1T',
-                  'L1T_workspace_slim':'L1T',
-                  'CSC':'CSC',
-                  'RPC':'RPC',
-                  'DT':'DT'})
+main_config = cfg.get_main(os.environ['ADQM_CONFIG'])
+OnlineMap = main_config["OnlineDataMap"]
+
 
 class DQMSession(FuturesSession):
     """Encapsulates an interface to DQM Offline."""

--- a/config/L1T_workspace.json
+++ b/config/L1T_workspace.json
@@ -1,0 +1,184 @@
+{
+  "main_gdir": "DQMData/Run {0}/L1T/Run summary/",
+  "hists": [
+
+    {
+      "path": "L1TStage2CaloLayer1/ecalOccRecdEtWgt"
+    },
+    {
+      "path": "L1TStage2CaloLayer1/hcalOccRecdEtWgt"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonBXvsLink"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPt"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonEta"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPhi"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPhivsEta"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_before_prescale_bx_global"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_after_prescale_bx_global"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_after_prescale_bx_inEvt"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_after_prescale"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Central-Jets/CenJetsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Forward-Jets/ForJetsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-EG/IsoEGsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-EG/NonIsoEGsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-Tau/IsoTausBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-Tau/TausBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/CenJetsEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Central-Jets/CenJetsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/ForJetsEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Forward-Jets/ForJetsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/IsoEGsEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-EG/IsoEGsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/NonIsoEGsEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-EG/NonIsoEGsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/IsoTausEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-Tau/IsoTausRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/shifter/TausEtEtaPhi_shift"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-Tau/TausRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/EtSumBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/ETTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/ETTEMRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/HTTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METHFRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METHFPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTHFRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTHFPhi"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFBX"
+    },
+    {
+      "path": "L1TStage2BMTF/bmtf_wedge_bx"
+    },
+    {
+      "path": "L1TStage2BMTF/bmtf_hwPt"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFhwEta"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtBXvsProcessorOMTF"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiPos"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiNeg"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"
+    },
+    {
+      "path": "L1TStage2uGMT/EMTFInput/ugmtEMTFBX"
+    },
+    {
+      "path": "L1TStage2EMTF/emtfTrackBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPhiEmtf"
+    },
+    {
+      "path": "L1TStage2EMTF/cscLCTOccupancy"
+    }
+
+  ]
+}

--- a/config/L1T_workspace_slim.json
+++ b/config/L1T_workspace_slim.json
@@ -1,0 +1,151 @@
+{
+  "main_gdir": "DQMData/Run {0}/L1T/Run summary/",
+  "hists": [
+
+    {
+      "path": "L1TStage2uGMT/ugmtMuonBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonBXvsLink"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPt"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonEta"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPhi"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_after_prescale_bx_inEvt"
+    },
+    {
+      "path": "L1TStage2uGT/algoBits_after_prescale"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Central-Jets/CenJetsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Forward-Jets/ForJetsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-EG/IsoEGsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-EG/NonIsoEGsBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-Tau/IsoTausBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-Tau/TausBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Central-Jets/CenJetsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Forward-Jets/ForJetsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-EG/IsoEGsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-EG/NonIsoEGsRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Isolated-Tau/IsoTausRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/NonIsolated-Tau/TausRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/EtSumBxOcc"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/ETTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/ETTEMRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/HTTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METHFRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/METHFPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTPhi"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTHFRank"
+    },
+    {
+      "path": "L1TStage2CaloLayer2/Energy-Sums/MHTHFPhi"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFBX"
+    },
+    {
+      "path": "L1TStage2BMTF/bmtf_wedge_bx"
+    },
+    {
+      "path": "L1TStage2BMTF/bmtf_hwPt"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFhwEta"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFglbhwPhi"
+    },
+    {
+      "path": "L1TStage2uGMT/BMTFInput/ugmtBMTFhwSign"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtBXvsProcessorOMTF"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwPt"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwEta"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiPos"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFglbhwPhiNeg"
+    },
+    {
+      "path": "L1TStage2uGMT/OMTFInput/ugmtOMTFhwSign"
+    },
+    {
+      "path": "L1TStage2uGMT/EMTFInput/ugmtEMTFBX"
+    },
+    {
+      "path": "L1TStage2EMTF/emtfTrackBX"
+    },
+    {
+      "path": "L1TStage2uGMT/ugmtMuonPhiEmtf"
+    },
+    {
+      "path": "L1TStage2EMTF/cscLCTOccupancy"
+    }
+
+  ]
+}

--- a/config/main.json
+++ b/config/main.json
@@ -1,0 +1,15 @@
+{
+  "OnlineDataMap": {
+    "CaloLayer1": "L1T",
+    "CaloLayer2": "L1T",
+    "BMTF": "L1T",
+    "EMTF": "L1T",
+    "OMTF": "L1T",
+    "uGMT": "L1T",
+    "L1T_workspace": "L1T",
+    "L1T_workspace_slim": "L1T",
+    "CSC": "CSC",
+    "RPC": "RPC",
+    "DT": "DT"
+  }
+}

--- a/index.py
+++ b/index.py
@@ -24,7 +24,7 @@ def handle_request(req):
     try:
         load_vars()
         if req['type'] == "fetch_run":
-            data = fetch_run(req['dqmSource'], req['series'], req['sample'], req['run'])
+            data = fetch_run(req['dqmSource'], req['subsystem'], req['series'], req['sample'], req['run'])
         elif req['type'] == "process":
             data = process(int(req['chunk_index']),
                            int(req['chunk_size']),
@@ -45,7 +45,7 @@ def handle_request(req):
         elif req['type'] == "get_samples":
             data = get_samples(req['dqmSource'], req['series'])
         elif req['type'] == "get_runs":
-            data = get_runs(req['dqmSource'], req['series'], req['sample'])
+            data = get_runs(req['dqmSource'], req['subsystem'], req['series'], req['sample'])
         elif req['type'] == "get_ref":
             data = get_ref(req['dqmSource'],
                            req['subsystem'],
@@ -69,9 +69,9 @@ def handle_request(req):
         return res
 
 
-def fetch_run(dqmSource, series, sample, run):
+def fetch_run(dqmSource, subsystem, series, sample, run):
     with make_dqm() as dqm:
-        dqm.fetch_run(dqmSource, series, sample, run)
+        dqm.fetch_run(dqmSource, subsystem, series, sample, run)
     return {}
 
 
@@ -82,8 +82,8 @@ def process(chunk_index, chunk_size,
 
     with make_dqm() as dqm:
         # Get root file paths
-        data_path = dqm.fetch_run(dqmSource, data_series, data_sample, data_run)
-        ref_path = dqm.fetch_run(dqmSource, ref_series, ref_sample, ref_run)
+        data_path = dqm.fetch_run(dqmSource, subsystem, data_series, data_sample, data_run)
+        ref_path = dqm.fetch_run(dqmSource, subsystem, ref_series, ref_sample, ref_run)
 
     # Get config and results/plugins directories
     results_dir = os.path.join(VARS['PUBLIC'], 'results')
@@ -138,16 +138,16 @@ def get_samples(dqmSource, series):
     return {'items': [r._asdict() for r in rows]}
 
 
-def get_runs(dqmSource, series, sample):
+def get_runs(dqmSource, subsystem, series, sample):
     with make_dqm() as dqm:
         ## TODO: truncate list to reasonable range, e.g. 2018 and later - AWB 2022.05.23
-        rows = dqm.fetch_run_list(dqmSource, series, sample)
+        rows = dqm.fetch_run_list(dqmSource, subsystem, series, sample)
     return {'items': [r._asdict() for r in rows]}
 
 def get_ref(dqmSource, subsystem, data_run, series, sample):
     config_dir = VARS['CONFIG']
     with make_dqm() as dqm:
-        rows = dqm.fetch_run_list(dqmSource, series, sample)
+        rows = dqm.fetch_run_list(dqmSource, subsystem, series, sample)
     ref_runs = []
     for row in [r._asdict() for r in rows]:
         ref_runs.append(row['name'])

--- a/plugins/pca.py
+++ b/plugins/pca.py
@@ -28,13 +28,18 @@ def pca(histpair,
     data_hist = histpair.data_hist.values(flow=False)
     jar_dir = histpair.config["jar_dir"]
 
-    data_year = int(histpair.data_series[-4:])
+    # If series is Run2016, 2017, 2018, etc. look for .pkl file for trained PCA
+    try:    data_year = int(histpair.data_series[-4:])
+    # Otherwise assume there is no .pkl file
+    except: data_year = 'NONE'
     possible_pickles = glob.glob("/var/www/cgi-bin/models/pca/{0}/{1}/*_{2}.pkl".format(jar_dir,data_year, data_name))
+    # TODO: Path to .pkl file is ambiguous (should probably depend on 'Sample' as well),
+    # TODO: and only works for OfflineData, not OnlineData.  Should be fixed! - AWB 2022.06.04
     if len(possible_pickles) != 1:
         return None
     pca_pickle = pickle.load(open(possible_pickles[0], "rb"))
 
-    #Decalre data_hist_Entries
+    # Declare data_hist_Entries
     data_hist_Entries = np.sum(data_hist)
 
 

--- a/plugins/pullvals.py
+++ b/plugins/pullvals.py
@@ -22,7 +22,8 @@ def pullvals(histpair,
 
     # Check that the hists are histograms
     # Check that the hists are 2 dimensional
-    if not "2" in str(type(data_hist)) or not "2" in str(type(ref_hist)):
+    if not ( (       "TH2" in str(type(data_hist)) and       "TH2" in str(type(ref_hist)) ) or
+             ("TProfile2D" in str(type(data_hist)) and "TProfile2" in str(type(ref_hist)) ) ):
         return None
     # Extract values from TH2F or TProfile2D Format
     data_hist_norm = None

--- a/runoffline/run-offline.py
+++ b/runoffline/run-offline.py
@@ -35,11 +35,11 @@ def autodqm_offline(dqmSource, subsystem,
     with DQMSession(cert, db) as dqm:
         print('')
         print("Getting data root file...")
-        data_path = get_run(dqm, dqmSource, data_series, data_sample, data_run)
+        data_path = get_run(dqm, dqmSource, subsystem, data_series, data_sample, data_run)
 
         print('')
         print("Getting reference root file...")
-        ref_path = get_run(dqm, dqmSource, ref_series, ref_sample, ref_run)
+        ref_path = get_run(dqm, dqmSource, subsystem, ref_series, ref_sample, ref_run)
 
     print('')
     print("Processing results...")
@@ -53,8 +53,8 @@ def autodqm_offline(dqmSource, subsystem,
     return results
 
 
-def get_run(dqm, dqmSource, series, sample, run):
-    stream = dqm.stream_run(dqmSource, series, sample, run)
+def get_run(dqm, dqmSource, subsystem, series, sample, run):
+    stream = dqm.stream_run(dqmSource, subsystem, series, sample, run)
     first = next(stream)
     path = first.path
     if first.cur == first.total:

--- a/runoffline/run-offline.py
+++ b/runoffline/run-offline.py
@@ -15,7 +15,7 @@ from autodqm.compare_hists import process
 
 
 
-def autodqm_offline(subsystem,
+def autodqm_offline(dqmSource, subsystem,
                     data_run, data_sample, data_series,
                     ref_run, ref_sample, ref_series,
                     cfg_dir, output_dir, plugin_dir,
@@ -35,15 +35,15 @@ def autodqm_offline(subsystem,
     with DQMSession(cert, db) as dqm:
         print('')
         print("Getting data root file...")
-        data_path = get_run(dqm, data_series, data_sample, data_run)
+        data_path = get_run(dqm, dqmSource, data_series, data_sample, data_run)
 
         print('')
         print("Getting reference root file...")
-        ref_path = get_run(dqm, ref_series, ref_sample, ref_run)
+        ref_path = get_run(dqm, dqmSource, ref_series, ref_sample, ref_run)
 
     print('')
     print("Processing results...")
-    results = process(0, 9999, cfg_dir, subsystem,
+    results = process(0, 9999, cfg_dir, dqmSource, subsystem,
                       data_series, data_sample, data_run, data_path,
                       ref_series, ref_sample, ref_run, ref_path,
                       output_dir=output_dir, plugin_dir=plugin_dir)
@@ -53,8 +53,8 @@ def autodqm_offline(subsystem,
     return results
 
 
-def get_run(dqm, series, sample, run):
-    stream = dqm.stream_run(series, sample, run)
+def get_run(dqm, dqmSource, series, sample, run):
+    stream = dqm.stream_run(dqmSource, series, sample, run)
     first = next(stream)
     path = first.path
     if first.cur == first.total:
@@ -84,6 +84,8 @@ if __name__ == '__main__':
 
     # Collect command line arguments
     parser = argparse.ArgumentParser(description='Run AutoDQM offline.')
+    parser.add_argument('dqmSource', type=str,
+                        help="dqmSource configuration to use. Online or Offline")
     parser.add_argument('subsystem', type=str,
                         help="subsystem configuration to use. Examples: CSC, EMTF")
 
@@ -118,7 +120,7 @@ if __name__ == '__main__':
     sslcert = find_file(args.sslcert)
     sslkey = find_file(args.sslkey)
 
-    autodqm_offline(args.subsystem,
+    autodqm_offline(args.dqmSource, args.subsystem,
                     args.data_run, args.data_sample, args.data_series,
                     args.ref_run, args.ref_sample, args.ref_series,
                     cfg_dir=args.config,

--- a/webapp/src/App.js
+++ b/webapp/src/App.js
@@ -62,7 +62,7 @@ class App extends Component {
               )}
             />
             <Route
-              path="/plots/:subsystem/:refSeries/:refSample/:refRun/:dataSeries/:dataSample/:dataRun" 
+              path="/plots/:dqmSource/:subsystem/:refSeries/:refSample/:refRun/:dataSeries/:dataSample/:dataRun" 
               render={props => (
                 <PlotsPage onNewQuery={this.handleNewQuery} {...props} />
               )}

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -2,31 +2,36 @@ import axios from 'axios';
 
 const API = '/dqm/autodqm/cgi-bin/index.py';
 
+export function getDqmSources() {
+  return cancellableQuery(API, {type: 'get_dqmSources'});
+}
+
 export function getSubsystems() {
   return cancellableQuery(API, {type: 'get_subsystems'});
 }
 
-export function getSeries() {
-  return cancellableQuery(API, {type: 'get_series'});
+export function getSeries(dqmSource) {
+  return cancellableQuery(API, {type: 'get_series', dqmSource});
 }
 
-export function getSamples(series) {
-  return cancellableQuery(API, {type: 'get_samples', series});
+export function getSamples(dqmSource, series) {
+  return cancellableQuery(API, {type: 'get_samples', dqmSource, series});
 }
 
-export function getRuns(series, sample) {
-  return cancellableQuery(API, {type: 'get_runs', series, sample});
+export function getRuns(dqmSource, series, sample) {
+  return cancellableQuery(API, {type: 'get_runs', dqmSource, series, sample});
 }
 
-export function getReferences(subsystem, series, sample, run) {
-  return cancellableQuery(API, {type: 'get_ref', subsystem, series, sample, run});
+export function getReferences(dqmSource, subsystem, series, sample, run) {
+  return cancellableQuery(API, {type: 'get_ref', dqmSource, subsystem, series, sample, run});
 }
 
-export function loadRun(series, sample, run) {
-  return cancellableQuery(API, {type: 'fetch_run', series, sample, run});
+export function loadRun(dqmSource, series, sample, run) {
+  return cancellableQuery(API, {type: 'fetch_run', dqmSource, series, sample, run});
 }
 
 export function generateReport({
+  dqmSource,
   subsystem,
   refSeries,
   refSample,
@@ -39,6 +44,7 @@ export function generateReport({
     type: 'process',
     chunk_index: chunk_index,
     chunk_size: chunk_size,
+    dqmSource: dqmSource,
     subsystem: subsystem,
     ref_series: refSeries,
     ref_sample: refSample,
@@ -50,6 +56,7 @@ export function generateReport({
 }
 
 export function queryUrl({
+  dqmSource,
   subsystem,
   refSeries,
   refSample,
@@ -59,6 +66,7 @@ export function queryUrl({
   dataRun,
 }) {
   const params = [
+    dqmSource,
     subsystem,
     refSeries,
     refSample,

--- a/webapp/src/api.js
+++ b/webapp/src/api.js
@@ -18,16 +18,16 @@ export function getSamples(dqmSource, series) {
   return cancellableQuery(API, {type: 'get_samples', dqmSource, series});
 }
 
-export function getRuns(dqmSource, series, sample) {
-  return cancellableQuery(API, {type: 'get_runs', dqmSource, series, sample});
+export function getRuns(dqmSource, subsystem, series, sample) {
+  return cancellableQuery(API, {type: 'get_runs', dqmSource, subsystem, series, sample});
 }
 
 export function getReferences(dqmSource, subsystem, series, sample, run) {
   return cancellableQuery(API, {type: 'get_ref', dqmSource, subsystem, series, sample, run});
 }
 
-export function loadRun(dqmSource, series, sample, run) {
-  return cancellableQuery(API, {type: 'fetch_run', dqmSource, series, sample, run});
+export function loadRun(dqmSource, subsystem, series, sample, run) {
+  return cancellableQuery(API, {type: 'fetch_run', dqmSource, subsystem, series, sample, run});
 }
 
 export function generateReport({

--- a/webapp/src/input/ApiSelect.js
+++ b/webapp/src/input/ApiSelect.js
@@ -26,6 +26,7 @@ export default class ApiSelect extends Component {
     const curP = this.props;
     if (
       prevP.type !== curP.type ||
+      prevP.dqmSource !== curP.dqmSource ||
       prevP.series !== curP.series ||
       prevP.sample !== curP.sample ||
       prevP.onError !== curP.onError ||
@@ -48,16 +49,23 @@ export default class ApiSelect extends Component {
   };
 
   loadOptions = () => {
+
+    // const {type, dqmSource, series, sample, onError, onLoad} = this.props;
+    // FIXME: Line above doesn't work: dqmSource null or does not exist. - AWB 2022.05.25
+    // FIXME: Temporarily using two lines below, hard-coding dqmSource to Online. - AWB 2022.05.25
     const {type, series, sample, onError, onLoad} = this.props;
+    const dqmSource = "Online";
     let req;
     if (type === 'get_runs' && series && sample) {
-      req = api.getRuns(series, sample);
+      req = api.getRuns(dqmSource, series, sample);
     } else if (type === 'get_samples' && series) {
-      req = api.getSamples(series);
-    } else if (type === 'get_series') {
-      req = api.getSeries();
+      req = api.getSamples(dqmSource, series);
+    } else if (type === 'get_series' && dqmSource) {
+      req = api.getSeries(dqmSource);
     } else if (type === 'get_subsystems') {
       req = api.getSubsystems();
+    } else if (type === 'get_dqmSources') {
+      req = api.getDqmSources();
     } else {
       return;
     }
@@ -72,7 +80,8 @@ export default class ApiSelect extends Component {
           .sort((a, b) => a.label.localeCompare(b.label));
         onLoad && onLoad([...opts]);
 
-        if(type === 'get_runs') opts.reverse();
+        if ( type === 'get_runs' ||
+	     (dqmSource === "Online" && (type === 'get_series' || type === 'get_sample')) ) opts.reverse();
         this.setState({opts, req: null});
       })
       .catch(err => {
@@ -82,7 +91,7 @@ export default class ApiSelect extends Component {
   };
 
   render() {
-    const {type, series, sample, onError, onLoad, ...selectProps} = this.props;
+    const {type, dqmSource, series, sample, onError, onLoad, ...selectProps} = this.props;
     return (
       <div style={{position: "relative"}}>
         <Select

--- a/webapp/src/input/ApiSelect.js
+++ b/webapp/src/input/ApiSelect.js
@@ -27,6 +27,7 @@ export default class ApiSelect extends Component {
     if (
       prevP.type !== curP.type ||
       prevP.dqmSource !== curP.dqmSource ||
+      prevP.subsystem !== curP.subsystem ||
       prevP.series !== curP.series ||
       prevP.sample !== curP.sample ||
       prevP.onError !== curP.onError ||
@@ -50,15 +51,11 @@ export default class ApiSelect extends Component {
 
   loadOptions = () => {
 
-    // const {type, dqmSource, series, sample, onError, onLoad} = this.props;
-    // FIXME: Line above doesn't work: dqmSource null or does not exist. - AWB 2022.05.25
-    // FIXME: Temporarily using two lines below, hard-coding dqmSource to Online. - AWB 2022.05.25
-    const {type, series, sample, onError, onLoad} = this.props;
-    const dqmSource = "Online";
+    const {type, dqmSource, subsystem, series, sample, onError, onLoad} = this.props;
     let req;
-    if (type === 'get_runs' && series && sample) {
-      req = api.getRuns(dqmSource, series, sample);
-    } else if (type === 'get_samples' && series) {
+    if (type === 'get_runs' && dqmSource && subsystem && series && sample) {
+      req = api.getRuns(dqmSource, subsystem, series, sample);
+    } else if (type === 'get_samples' && dqmSource && series) {
       req = api.getSamples(dqmSource, series);
     } else if (type === 'get_series' && dqmSource) {
       req = api.getSeries(dqmSource);
@@ -91,7 +88,7 @@ export default class ApiSelect extends Component {
   };
 
   render() {
-    const {type, dqmSource, series, sample, onError, onLoad, ...selectProps} = this.props;
+    const {type, dqmSource, subsystem, series, sample, onError, onLoad, ...selectProps} = this.props;
     return (
       <div style={{position: "relative"}}>
         <Select

--- a/webapp/src/input/ApiSelect.js
+++ b/webapp/src/input/ApiSelect.js
@@ -78,7 +78,7 @@ export default class ApiSelect extends Component {
         onLoad && onLoad([...opts]);
 
         if ( type === 'get_runs' ||
-	     (dqmSource === "Online" && (type === 'get_series' || type === 'get_sample')) ) opts.reverse();
+	     (dqmSource === "Online" && (type === 'get_series' || type === 'get_samples')) ) opts.reverse();
         this.setState({opts, req: null});
       })
       .catch(err => {

--- a/webapp/src/input/InputForm.js
+++ b/webapp/src/input/InputForm.js
@@ -33,8 +33,8 @@ export default class InputForm extends Component {
 
   render() {
     const q = this.props.query;
-    const data = {series: q.dataSeries, sample: q.dataSample, run: q.dataRun};
-    const ref = {series: q.refSeries, sample: q.refSample, run: q.refRun};
+    const data = {dqmSource: q.dqmSource, subsystem: q.subsystem, series: q.dataSeries, sample: q.dataSample, run: q.dataRun};
+    const ref = {dqmSource: q.dqmSource, subsystem: q.subsystem, series: q.refSeries, sample: q.refSample, run: q.refRun};
 
     return (
       <React.Fragment>
@@ -110,6 +110,7 @@ function RunSelectForm(props) {
       <ApiSelect
         placeholder="Select series..."
         type="get_series"
+        dqmSource={props.dqmSource}
         value={option(props.series)}
         onChange={c => props.onChange('series', c)}
       />
@@ -117,6 +118,7 @@ function RunSelectForm(props) {
       <ApiSelect
         placeholder="Select sample..."
         type="get_samples"
+        dqmSource={props.dqmSource}
         series={props.series}
         value={option(props.sample)}
         onChange={c => props.onChange('sample', c)}
@@ -125,6 +127,8 @@ function RunSelectForm(props) {
       <ApiSelect
         placeholder="Select run..."
         type="get_runs"
+        dqmSource={props.dqmSource}
+        subsystem={props.subsystem}
         series={props.series}
         sample={props.sample}
         value={option(props.run)}

--- a/webapp/src/input/InputForm.js
+++ b/webapp/src/input/InputForm.js
@@ -11,6 +11,10 @@ export default class InputForm extends Component {
     return api.queryUrl(query);
   };
 
+  handleDqmSourceChange = change => {
+    this.props.onChange({dqmSource: change.value});
+  };
+
   handleSubsystemChange = change => {
     this.props.onChange({subsystem: change.value});
   };
@@ -38,6 +42,20 @@ export default class InputForm extends Component {
           <Col>
             <Row>
               <Col>
+                <h3>Source</h3>
+              </Col>
+              <Col/>
+            </Row>
+            <ApiSelect
+              placeholder="Select DQM source..."
+              type="get_dqmSources"
+              value={option(q.dqmSource)}
+              onChange={this.handleDqmSourceChange}
+            />
+          </Col>
+          <Col>
+            <Row>
+              <Col>
                 <h3>Subsystem</h3>
               </Col>
               <Col/>
@@ -61,7 +79,7 @@ export default class InputForm extends Component {
             <RunSelectForm {...data} onChange={this.handleDataChange} />
           </Col>
           <Col md="6">
-            <h3>Ref Run</h3>
+            <h3>Reference Run</h3>
             <RunSelectForm {...ref} onChange={this.handleRefChange} />
           </Col>
         </Row>

--- a/webapp/src/input/InputPage.js
+++ b/webapp/src/input/InputPage.js
@@ -18,6 +18,7 @@ export default class InputPage extends Component {
     this.state = {
       refEqualsData,
       query: {
+        dqmSource: null,
         subsystem: null,
         refSeries: null,
         refSample: null,
@@ -67,6 +68,7 @@ export default class InputPage extends Component {
     this.setState({
       refEqualsData: true,
       query: {
+        dqmSource: null,
         subsystem: null,
         refSeries: null,
         refSample: null,
@@ -92,6 +94,7 @@ export default class InputPage extends Component {
           </Col>
           <Col md="6">
             <RefSuggestions
+              dqmSource={query.dqmSource}
               subsystem={query.subsystem}
               series={query.dataSeries}
               sample={query.dataSample}

--- a/webapp/src/input/RefSuggestions.js
+++ b/webapp/src/input/RefSuggestions.js
@@ -29,6 +29,7 @@ export default class RefSuggestions extends Component {
 
   componentDidUpdate = prevProps => {
     if (
+      this.props.dqmSource !== prevProps.dqmSource ||
       this.props.subsystem !== prevProps.subsystem ||
       this.props.series !== prevProps.series ||
       this.props.sample !== prevProps.sample ||
@@ -39,13 +40,13 @@ export default class RefSuggestions extends Component {
   };
 
   loadRefs = () => {
-    let {subsystem, series, sample, run} = this.props;
+    let {dqmSource, subsystem, series, sample, run} = this.props;
 
-    if (!subsystem || !series || !sample || !run) {
+    if (!dqmSource || !subsystem || !series || !sample || !run) {
       this.state.refReq && this.state.refReq.cancel();
       this.setState({refReq: null, refCands: []});
     } else {
-      let r = api.getReferences(subsystem, series, sample, run);
+      let r = api.getReferences(dqmSource, subsystem, series, sample, run);
       this.setState({refReq: r});
 
       r.then(res => {

--- a/webapp/src/plots/Controls.js
+++ b/webapp/src/plots/Controls.js
@@ -76,6 +76,7 @@ class RunSwitch extends Component {
 
   switchRun = run => {
     const params = [
+      this.props.dqmSource,
       this.props.subsystem,
       this.props.refSeries,
       this.props.refSample,

--- a/webapp/src/plots/PlotsPage.js
+++ b/webapp/src/plots/PlotsPage.js
@@ -93,8 +93,8 @@ export default class PlotsPage extends Component {
   };
 
   loadReport = query => {
-    const refReq  = api.loadRun(query.dqmSource, query.refSeries, query.refSample, query.refRun);
-    const dataReq = api.loadRun(query.dqmSource, query.dataSeries, query.dataSample, query.dataRun);
+    const refReq  = api.loadRun(query.dqmSource, query.subsystem, query.refSeries, query.refSample, query.refRun);
+    const dataReq = api.loadRun(query.dqmSource, query.subsystem, query.dataSeries, query.dataSample, query.dataRun);
     this.setState({refReq, dataReq, showLoading: true});
 
     refReq.then(res => {

--- a/webapp/src/plots/PlotsPage.js
+++ b/webapp/src/plots/PlotsPage.js
@@ -81,7 +81,7 @@ export default class PlotsPage extends Component {
         procReq.then(res => {
             plots = plots.concat(res.items);
             chunk_index = res.chunk_index;
-            if(chunk_index == -1)
+            if(chunk_index === -1)
             {
               this.setState({plots, procReq: null, showLoading: false});
             }else
@@ -93,12 +93,8 @@ export default class PlotsPage extends Component {
   };
 
   loadReport = query => {
-    const refReq = api.loadRun(query.refSeries, query.refSample, query.refRun);
-    const dataReq = api.loadRun(
-      query.dataSeries,
-      query.dataSample,
-      query.dataRun,
-    );
+    const refReq  = api.loadRun(query.dqmSource, query.refSeries, query.refSample, query.refRun);
+    const dataReq = api.loadRun(query.dqmSource, query.dataSeries, query.dataSample, query.dataRun);
     this.setState({refReq, dataReq, showLoading: true});
 
     refReq.then(res => {
@@ -139,6 +135,7 @@ export default class PlotsPage extends Component {
 
   validParams = params => {
     return (
+      params.dqmSource &&
       params.subsystem &&
       params.refSeries &&
       params.refSample &&

--- a/webapp/src/plots/ReportInfo.js
+++ b/webapp/src/plots/ReportInfo.js
@@ -8,6 +8,7 @@ export default function ReportInfo(props) {
         <Row>
           <Col md="6" lg="4">
             <h2>AutoDQM Report</h2>
+            <h4>DQM source: {props.dqmSource}</h4>
             <h4>Subsystem: {props.subsystem}</h4>
             <small className="text-muted">{props.timestamp}</small>
           </Col>


### PR DESCRIPTION
Hi all,

These modifications should in principle be "transparent" to any previous uses of the AutoDQM tool.  I've added the capability to access the OnlineData, i.e. histograms used in the Online DQM.

I also added configs corresponding to histograms in the L1T workspace seen by shifters, as listed here:
https://github.com/dmwm/deployment/blob/master/dqmgui/layouts/l1t-layouts.py

Please take a look, and try it out, and let me know if there's anything you think should be changed!

Best regards,
Andrew