### PR TITLE
fixed previous/next buttons

### DIFF
--- a/webapp/src/plots/Controls.js
+++ b/webapp/src/plots/Controls.js
@@ -119,6 +119,8 @@ class RunSwitch extends Component {
         <Col xs="4" className="p-0">
           <ApiSelect
             type="get_runs"
+            dqmSource={this.props.dqmSource}
+            subsystem={this.props.subsystem}
             series={this.props.dataSeries}
             sample={this.props.dataSample}
             onChange={c => this.switchRun(c.value)}


### PR DESCRIPTION
plots page previous/next buttons to move data runs were broken before. Addresses this issue https://github.com/AutoDQM/AutoDQM/issues/77 