### PR TITLE
specify python version in offline

### DIFF
--- a/runoffline/environment.yml
+++ b/runoffline/environment.yml
@@ -18,4 +18,4 @@ dependencies:
   - tqdm
   - uproot
   - urllib3
-  - python
+

--- a/runoffline/environment.yml
+++ b/runoffline/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
+  - python=3.6
   - certifi
   - chardet
   - idna
@@ -18,5 +19,3 @@ dependencies:
   - uproot
   - urllib3
   - python
-
-


### PR DESCRIPTION
to run autodqm offline, we need to be sure the python version is <=3.7 (else generators do not work correctly). I specify the python version in runoffline/environment.yml for the creation of a correct conda environment.