### PR TITLE
Flag empty plots as anomalous

### DIFF
--- a/autodqm/compare_hists.py
+++ b/autodqm/compare_hists.py
@@ -69,10 +69,12 @@ def process(chunk_index, chunk_size, config_dir,
                                 MaxPull_params = entry["param_MaxPull"]
                                 Chi2_params = entry["param_Chi2"]
                                 MaxPull_threshold = calc_threshold(len(ref_runs), MaxPull_params[0],MaxPull_params[1])
-                                chi2_threshold    = calc_threshold(len(ref_runs), Chi2_params[0],Chi2_params[1])
+                                # The factor 0.8 is added here as DT thresholds were a bit too tight, due to their derivation using randon reference runs
+                                #instead of runs imediatily before the 'data' run, which make the thresholds tighter. 
+                                chi2_threshold    = 0.8*calc_threshold(len(ref_runs), Chi2_params[0],Chi2_params[1])
                     if MaxPull_threshold > 36:
                         MaxPull_threshold = 36 
-                    results = comparator(hp, **hp.config, chi2_cut=chi2_threshold, pull_cut= MaxPull_threshold)   
+                    results = comparator(hp, **hp.config, chi2_cut=chi2_threshold, pull_cut= MaxPull_threshold, subsystem = subsystem )   
                 else:
                     results = comparator(hp, **hp.config)
                     

--- a/autodqm/rebin_utils.py
+++ b/autodqm/rebin_utils.py
@@ -10,11 +10,11 @@ These algorithms were developed to mitigate this effect and increase the relativ
 import numpy as np
 
 # Instead of rebinning the data and reference histograms, we will rebin the pull histogram
-def rebin_pull_hist(pull_hist_orig):
+def rebin_pull_hist(pull_hist_orig, nBinsUsed):
 
         import plugins.beta_binomial as bb
 
-        nBinsUsed_orig = np.count_nonzero(pull_hist_orig)	
+        nBinsUsed_orig = nBinsUsed #np.count_nonzero(pull_hist_orig)	
         pull_hist = pull_hist_orig.copy()
 
 	# Applying the hot-bin algorithm

--- a/plugins/beta_binomial.py
+++ b/plugins/beta_binomial.py
@@ -112,7 +112,7 @@ def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1
 
     # For test propouses! - should we do it only for Occupancy plots??
     if 'Occupancy' in histpair.data_name:
-        chi2 = rebin_pull_hist(pull_hist)
+        chi2 = rebin_pull_hist(pull_hist, nBinsUsed)
 
     ## access per-histogram settings for max_pull, chi2, axis titles
     plot_title  = None

--- a/plugins/beta_binomial.py
+++ b/plugins/beta_binomial.py
@@ -49,7 +49,7 @@ def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1
     nRef = len(ref_hists_raw)
 
     ## Does not run beta_binomial if data or ref is 0
-    if np.sum(data_hist_raw) <= 0 or nRef == 0:
+    if nRef == 0:
         return None
 
     ## Adjust x-axis range for 1D plots if option set in config file
@@ -129,6 +129,16 @@ def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1
 
     ## define if plot anomalous
     is_outlier = data_hist_Entries >= min_entries and (chi2 > chi2_cut or abs(max_pull) > pull_cut)
+
+
+    if data_hist_Entries < 1 and np.all(np.array(ref_hist_Entries) > 0):
+        is_outlier = True
+        pull_hist = -1000*np.ones_like(pull_hist)
+        chi2 = np.square(pull_hist).sum()/nBinsUsed
+        max_pull = maxPullNorm(np.amax(pull_hist), nBinsUsed)
+        min_pull = maxPullNorm(np.amin(pull_hist), nBinsUsed)
+        if abs(min_pull) > max_pull:
+            max_pull = min_pull
 
     ## For subsystems with many many plots (e.g. DT_DOC1), only generate somewhat anomalous plots
     sel_display_chi2    = -1.0

--- a/plugins/beta_binomial.py
+++ b/plugins/beta_binomial.py
@@ -131,7 +131,7 @@ def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1
     is_outlier = data_hist_Entries >= min_entries and (chi2 > chi2_cut or abs(max_pull) > pull_cut)
 
 
-    if data_hist_Entries < 1 and np.all(np.array(ref_hist_Entries) > 0) and subsystem == 'DT':
+    if data_hist_Entries < 1 and np.all(np.array(ref_hist_Entries) > 0) and subsystem.startswith('DT'):
         is_outlier = True
         pull_hist = -1000*np.ones_like(pull_hist)
         chi2 = np.square(pull_hist).sum()/nBinsUsed

--- a/plugins/beta_binomial.py
+++ b/plugins/beta_binomial.py
@@ -15,7 +15,7 @@ def comparators():
         'beta_binomial' : beta_binomial
     }
 
-def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1, tol=0.01, norm_type='all', **kwargs):
+def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1, tol=0.01, norm_type='all',subsystem=None, **kwargs):
     """beta_binomial works on both 1D and 2D"""
     data_hist_orig = histpair.data_hist
     ref_hists_orig = [rh for rh in histpair.ref_hists if rh.values().size == data_hist_orig.values().size]
@@ -131,7 +131,7 @@ def beta_binomial(histpair, pull_cap=10, chi2_cut=10, pull_cut=10, min_entries=1
     is_outlier = data_hist_Entries >= min_entries and (chi2 > chi2_cut or abs(max_pull) > pull_cut)
 
 
-    if data_hist_Entries < 1 and np.all(np.array(ref_hist_Entries) > 0):
+    if data_hist_Entries < 1 and np.all(np.array(ref_hist_Entries) > 0) and subsystem == 'DT':
         is_outlier = True
         pull_hist = -1000*np.ones_like(pull_hist)
         chi2 = np.square(pull_hist).sum()/nBinsUsed


### PR DESCRIPTION
This MR add the feature that it shows and flag histograms that are empty in the data run, but are not empty in the reference runs. This feature is only used in DT

Also, the chi2 thresholds were fine tuned to 80% of the derived thresholds, due to current thresholds being too tight